### PR TITLE
SIGSYS to socket

### DIFF
--- a/src/rkr/tracing/Process.cc
+++ b/src/rkr/tracing/Process.cc
@@ -129,8 +129,14 @@ bool Process::tryCloseFD(Build& build, const IRSource& source, int fd) noexcept 
 // Set a file descriptor's close-on-exec flag
 void Process::setCloexec(int fd, bool cloexec) noexcept {
   auto iter = _fds.find(fd);
-  ASSERT(iter != _fds.end())
+  // ERIC
+//  ASSERT(iter != _fds.end())
+//      << "Attempted to set the cloexec flag for non-existent file descriptor " << fd;
+  if (iter != _fds.end()) {
+      WARN
       << "Attempted to set the cloexec flag for non-existent file descriptor " << fd;
+  }
+
 
   const auto& [ref, old_cloexec] = iter->second;
   iter->second = FileDescriptor{ref, cloexec};

--- a/src/rkr/tracing/Process.cc
+++ b/src/rkr/tracing/Process.cc
@@ -129,12 +129,8 @@ bool Process::tryCloseFD(Build& build, const IRSource& source, int fd) noexcept 
 // Set a file descriptor's close-on-exec flag
 void Process::setCloexec(int fd, bool cloexec) noexcept {
   auto iter = _fds.find(fd);
-  // ERIC
-  //ASSERT(iter != _fds.end())
-  //    << "Attempted to set the cloexec flag for non-existent file descriptor " << fd;
-  if (iter != _fds.end()) {
-      WARN << "Attempted to set the cloexec flag for non-existent file descriptor " << fd;
-  }
+  ASSERT(iter != _fds.end())
+      << "Attempted to set the cloexec flag for non-existent file descriptor " << fd;
 
   const auto& [ref, old_cloexec] = iter->second;
   iter->second = FileDescriptor{ref, cloexec};

--- a/src/rkr/tracing/Process.cc
+++ b/src/rkr/tracing/Process.cc
@@ -130,13 +130,11 @@ bool Process::tryCloseFD(Build& build, const IRSource& source, int fd) noexcept 
 void Process::setCloexec(int fd, bool cloexec) noexcept {
   auto iter = _fds.find(fd);
   // ERIC
-//  ASSERT(iter != _fds.end())
-//      << "Attempted to set the cloexec flag for non-existent file descriptor " << fd;
+  //ASSERT(iter != _fds.end())
+  //    << "Attempted to set the cloexec flag for non-existent file descriptor " << fd;
   if (iter != _fds.end()) {
-      WARN
-      << "Attempted to set the cloexec flag for non-existent file descriptor " << fd;
+      WARN << "Attempted to set the cloexec flag for non-existent file descriptor " << fd;
   }
-
 
   const auto& [ref, old_cloexec] = iter->second;
   iter->second = FileDescriptor{ref, cloexec};

--- a/src/rkr/tracing/Tracer.cc
+++ b/src/rkr/tracing/Tracer.cc
@@ -556,7 +556,7 @@ shared_ptr<Process> Tracer::launchTraced(Build& build, const shared_ptr<Command>
       } else if (SyscallTable<Build>::get(i).isBlocked()) {
           bpf.push_back(BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, i, 0, 1));
           //bpf.push_back(BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW));
-          bpf.push_back(BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ERRNO | (EADV & SECCOMP_RET_DATA)));
+          bpf.push_back(BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ERRNO | (EPERM & SECCOMP_RET_DATA)));
           //bpf.push_back(BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_TRACE));
       } else {
         if (SyscallTable<Build>::get(i).isTraced()) {

--- a/src/rkr/tracing/Tracer.cc
+++ b/src/rkr/tracing/Tracer.cc
@@ -552,6 +552,12 @@ shared_ptr<Process> Tracer::launchTraced(Build& build, const shared_ptr<Command>
         bpf.push_back(BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW));
         bpf.push_back(BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_TRACE));
 
+        //ERIC WAS HERE
+      } else if (SyscallTable<Build>::get(i).isBlocked()) {
+          bpf.push_back(BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, i, 0, 1));
+          //bpf.push_back(BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW));
+          bpf.push_back(BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ERRNO | (EADV & SECCOMP_RET_DATA)));
+          //bpf.push_back(BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_TRACE));
       } else {
         if (SyscallTable<Build>::get(i).isTraced()) {
           // Check if the syscall matches the current entry. If it matches, trace the syscall.

--- a/src/rkr/tracing/Tracer.cc
+++ b/src/rkr/tracing/Tracer.cc
@@ -556,7 +556,8 @@ shared_ptr<Process> Tracer::launchTraced(Build& build, const shared_ptr<Command>
       } else if (SyscallTable<Build>::get(i).isBlocked()) {
           bpf.push_back(BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, i, 0, 1));
           //bpf.push_back(BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW));
-          bpf.push_back(BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ERRNO | (EPERM & SECCOMP_RET_DATA)));
+          //bpf.push_back(BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ERRNO | (SIGSYS & SECCOMP_RET_DATA)));
+          bpf.push_back(BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_KILL_PROCESS));
           //bpf.push_back(BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_TRACE));
       } else {
         if (SyscallTable<Build>::get(i).isTraced()) {

--- a/src/rkr/tracing/amd64/syscalls.hh
+++ b/src/rkr/tracing/amd64/syscalls.hh
@@ -45,7 +45,8 @@
 /* 038 */ // skip setitimer (__NR_setitimer)
 /* 039 */ // skip getpid (__NR_getpid)
 /* 040 */ TRACE(__NR_sendfile, sendfile);
-/* 041 */ TRACE(__NR_socket, socket);
+/* 041 */ // ERIC TRACE(__NR_socket, socket);
+/* 041 */ BLOCK(__NR_socket, socket);
 /* 042 */ // skip connect (__NR_connect)
 /* 043 */ // skip accept (__NR_accept)
 /* 044 */ TRACE(__NR_sendto, sendto);


### PR DESCRIPTION
Send SIGSYS to terminate the program trying to make a SOCKET call

```
eric@pashersn3ericsi:~/dynamic-parallelizer$ PASH_SPEC_TOP=$(pwd) ./parallel-orch/run_command.sh ../rikertest/test.sh a sandbox
Execution mode: sandbox
Overlay directory: /tmp/pash_spec/sandbox_p7CGQkT/
rkr-launch
Rikerfile
sh Rikerfile
sh ../rikertest/test.sh
dig @1.1 +short ericz.me
Bad system call (core dumped)
```

Weird behavior: the trace file will show the command as exitted with code zero. However since sandbox calls riker on every line in the script, Riker calls on commands that calls SOCKET will exit with 159.

159 = 128 + 31, 31 = sigsys

`[Command sh Rikerfile]: Exit(159)`
